### PR TITLE
patch the redirection when signing up

### DIFF
--- a/frontend/src/components/Register.js
+++ b/frontend/src/components/Register.js
@@ -31,7 +31,7 @@ const Register = () => {
       setToastVariant('success');
       setShowToast(true);
       setTimeout(() => {
-        navigate('/login');
+        navigate('/sign-in');
       }, 3000);
     } catch (error) {
       setToastMessage('Registration failed. Please try again.');


### PR DESCRIPTION
Register.js Line 34 Broken link. send the user to /login
The correct link is /sign-in
This have been patched